### PR TITLE
✨Integrated Bot Framework WebChat into the block_iagora plugin

### DIFF
--- a/block_iagora.php
+++ b/block_iagora.php
@@ -48,16 +48,32 @@ class block_iagora extends block_base {
 
         $this->content = new stdClass();
         $this->content->footer = '';
+        $copilotendpointurl = isset($this->config->copilotendpointurl) ? $this->config->copilotendpointurl : '';
 
-        $iframeurl = isset($this->config->iframeurl) ? $this->config->iframeurl : '';
-
-        if (empty($iframeurl)) {
-            $this->content->text = get_string('noiframeurl', 'block_iagora');
+        if (empty($copilotendpointurl)) {
+            $this->content->text = get_string('nocopilotendpointurl', 'block_iagora');
         } else {
-            $this->content->text = '<iframe src="' . $iframeurl . '" width="100%" height="400px" frameborder="0"></iframe>';
+            $this->content->text = $this->generate_chat_content($copilotendpointurl);
         }
-
         return $this->content;
+
+    }
+
+    /**
+     * Generate the HTML content for the chat block.
+     *
+     * @param string $copilotendpointurl The URL to be used in the iframe.
+     * @return string The generated HTML content for the chat.
+     */
+    private function generate_chat_content($copilotendpointurl) {
+        global $OUTPUT;
+        // Generate a unique identifier for the chat container.
+        $chatid = uniqid('iagora_chat_');
+        $context = [
+            'chatId' => $chatid,
+            'tokenEndpointURL' => $copilotendpointurl,
+        ];
+        return $OUTPUT->render_from_template('block_iagora/chat', $context);
     }
 
     /**
@@ -86,8 +102,8 @@ class block_iagora extends block_base {
      * @return bool True if data was saved successfully, false otherwise.
      */
     public function instance_config_save($data, $nolongerused = false) {
-        if (isset($data->iframeurl)) {
-            $data->iframeurl = clean_param($data->iframeurl, PARAM_URL);
+        if (isset($data->copilotendpointurl)) {
+            $data->copilotendpointurl = clean_param($data->copilotendpointurl, PARAM_URL);
         }
         return parent::instance_config_save($data, $nolongerused);
     }

--- a/edit_form.php
+++ b/edit_form.php
@@ -38,12 +38,11 @@ class block_iagora_edit_form extends block_edit_form {
         // Section header title according to language file.
         $mform->addElement('header', 'config_header', get_string('blocksettings', 'block'));
 
-        // Iframe URL.
-        $mform->addElement('text', 'config_iframeurl', get_string('iframeurl', 'block_iagora'));
-        $mform->setType('config_iframeurl', PARAM_URL);
-        $mform->addHelpButton('config_iframeurl', 'iframeurl', 'block_iagora');
-        $mform->setDefault('config_iframeurl', '');
-        $mform->addElement('static', 'iframeurl_desc', '', get_string('iframeurl_desc', 'block_iagora'));
+        $mform->addElement('text', 'config_copilotendpointurl', get_string('copilotendpointurl', 'block_iagora'));
+        $mform->setType('config_copilotendpointurl', PARAM_URL);
+        $mform->addHelpButton('config_copilotendpointurl', 'copilotendpointurl', 'block_iagora');
+        $mform->setDefault('config_copilotendpointurl', '');
+        $mform->addElement('static', 'copilotendpointurl_desc', '', get_string('copilotendpointurl_desc', 'block_iagora'));
 
     }
 

--- a/lang/en/block_iagora.php
+++ b/lang/en/block_iagora.php
@@ -22,8 +22,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
- $string['iframeurl'] = 'Iframe URL';
- $string['iframeurl_desc'] = 'Public URL available for chat iframe';
- $string['iframeurl_help'] = 'Public URL for the Microsoft Copilot chat iframe';
- $string['noiframeurl'] = 'No url defined for this block. Please configure a URL in the block parameters';
- $string['pluginname'] = 'IAGORA';
+$string['copilotendpointurl'] = 'Copilot URL';
+$string['copilotendpointurl_desc'] = 'Microsoft Copilot Token Endpoint URL';
+$string['copilotendpointurl_help'] = 'The Microsoft Copilot Token Endpoint URL is used to get the Direct Line token';
+$string['nocopilotendpointurl'] = 'No Copilot Endpoint URL defined for this block. Please configure it in the block parameters';
+$string['pluginname'] = 'IAGORA';

--- a/templates/chat.mustache
+++ b/templates/chat.mustache
@@ -1,0 +1,93 @@
+{{!
+    This file is part of Moodle - https://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template block_iagora/chat
+
+    Display the iagora chat block.
+
+    Classes required for JS:
+    * none
+
+    Data attributes required for JS:
+    * none
+
+    Context variables required for this template:
+    * chatId: The ID of the chat div element where to render the chat block.
+    * tokenEndpointURL: The Copilot Token Endpoint URL for native apps.
+
+    Example context (json):
+    {
+        "chatId": "iagora_chat_55a6cad25a0f6",
+        "tokenEndpointURL": "https://insert/your/copilot/endpoint/url"
+    }
+}}
+{{#pix}} t/message, core {{/pix}}
+<div id="{{chatId}}" role="main"></div>
+
+<script crossorigin="anonymous" src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
+
+{{#js}}
+/* global WebChat */
+/* eslint-disable promise/no-native */
+(async function() {
+  const styleOptions = {
+    hideUploadButton: true
+  };
+  const tokenEndpointURL = new URL('{{tokenEndpointURL}}');
+  const locale = document.documentElement.lang || 'en';
+  const apiVersion = tokenEndpointURL.searchParams.get('api-version');
+
+  const [directLineURL, token] = await Promise.all([
+    fetch(new URL(`/powervirtualagents/regionalchannelsettings?api-version=${apiVersion}`, tokenEndpointURL))
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Failed to retrieve regional channel settings.');
+        }
+        return response.json();
+      })
+      .then(({channelUrlsById: {directline}}) => directline),
+    fetch(tokenEndpointURL)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Failed to retrieve Direct Line token.');
+        }
+        return response.json();
+      })
+      .then(({token}) => token)
+  ]);
+
+  const directLine = WebChat.createDirectLine({domain: new URL('v3/directline', directLineURL), token});
+
+  const subscription = directLine.connectionStatus$.subscribe({
+    next(value) {
+      if (value === 2) {
+        directLine
+          .postActivity({
+            localTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            locale,
+            name: 'startConversation',
+            type: 'event'
+          })
+          .subscribe();
+        subscription.unsubscribe();
+      }
+    }
+  });
+
+  WebChat.renderWebChat({directLine, locale, styleOptions}, document.getElementById('{{chatId}}'));
+})();
+{{/js}}


### PR DESCRIPTION
Created and configured a Mustache template for dynamic chatbot rendering.

## Purpose

This Pull Request introduces a Mustache model to dynamically render the chatbot interface in the Moodle block. The aim of this change is to improve the flexibility and maintainability of the chatbot's user interface. 

**Why do we need it?
-The Mustache template makes it easy to customize the chatbot's appearance without directly modifying the PHP code.
-Changes to the user interface can be made independently of the backend logic.
**What features have been added?
- A dynamic Mustache model for the chatbot that can be easily customized and extended to meet future needs.

## Proposal

1. Create a template: Create a Mustache template file (`templates/chat.mustache`) that defines the structure and style of the chatbot interface.
2. Integration with PHP code:
   - Updated `block_iagora` class to use Mustache model for chatbot rendering.
   - Modified the `generate_chat_content` method to pass dynamic data to the Mustache model.
3. Dynamic rendering:
   - The Mustache model receives contextual data and renders the chatbot's user interface accordingly.
   
