### PR TITLE
💚(project) fix moodle-plugin-ci installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
                 php-version: ${{ matrix.php }}
                 ini-values: max_input_vars=5000
                 coverage: xdebug
-        
+
             - name: Initialise moodle-plugin-ci
               if: ${{ !cancelled() }}
               run: |
@@ -61,8 +61,10 @@ jobs:
                 echo $(cd ci/bin; pwd) >> $GITHUB_PATH
                 echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
                 sudo locale-gen en_AU.UTF-8
-                echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
-      
+                # Install nvm v0.39.7 as a temporary workaround for issue:
+                # https://github.com/moodlehq/moodle-plugin-ci/issues/309
+                curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+
             - name: Install moodle-plugin-ci
               if: ${{ !cancelled() }}
               run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1


### PR DESCRIPTION
## Purpose

<!-- Describe the purpose of this pull request. -->
<!-- Why is it needed? What problem does it solve? What feature does it add? -->
Our GitHub workflow fails to install `moodle-plugin-ci` due to an nvm update (v0.39.7 -> v0.40.0) in Ubuntu 22.04.

## Proposal

<!-- Describe the approach taken to achieve the purpose. -->
<!-- How is it implemented? What alternatives were considered? -->

As a workaround, we manually installed nvm v0.39.7 in the "Initialise moodle-plugin-ci" step.
See: [moodle-plugin-ci issue 309](https://github.com/moodlehq/moodle-plugin-ci/issues/309)