### PR TITLE
🔒️(project) move copilot token request to backend

### DIFF
--- a/block_iagora.php
+++ b/block_iagora.php
@@ -42,36 +42,45 @@ class block_iagora extends block_base {
      * @return string The block HTML.
      */
     public function get_content() {
-        if ($this->content !== null) {
+        if (isset($this->content)) {
             return $this->content;
         }
 
         $this->content = new stdClass();
         $this->content->footer = '';
-        $copilotendpointurl = isset($this->config->copilotendpointurl) ? $this->config->copilotendpointurl : '';
+        $copilotendpointurl = $this->config->copilotendpointurl;
+        $directlineurl = $this->config->directlineurl;
 
-        if (empty($copilotendpointurl)) {
+        if (!isset($copilotendpointurl)) {
             $this->content->text = get_string('nocopilotendpointurl', 'block_iagora');
-        } else {
-            $this->content->text = $this->generate_chat_content($copilotendpointurl);
+            return $this->content;
         }
-        return $this->content;
 
+        if(!isset($directlineurl)) {
+            $this->content->text = get_string('nodirectlineurl', 'block_iagora');
+            return $this->content;
+        }
+
+        $token = json_decode(file_get_contents($copilotendpointurl), true)['token'];
+        $this->content->text = $this->generate_chat_content($directlineurl, $token);
+        return $this->content;
     }
 
     /**
      * Generate the HTML content for the chat block.
      *
-     * @param string $copilotendpointurl The URL to be used in the iframe.
+     * @param string $directlineurl The Direct Line API base URL.
+     * @param string $token The Copilot Direct Line token.
      * @return string The generated HTML content for the chat.
      */
-    private function generate_chat_content($copilotendpointurl) {
+    private function generate_chat_content($directlineurl, $token) {
         global $OUTPUT;
         // Generate a unique identifier for the chat container.
         $chatid = uniqid('iagora_chat_');
         $context = [
             'chatId' => $chatid,
-            'tokenEndpointURL' => $copilotendpointurl,
+            'directLineURL' => $directlineurl,
+            'token' => $token,
         ];
         return $OUTPUT->render_from_template('block_iagora/chat', $context);
     }
@@ -104,7 +113,25 @@ class block_iagora extends block_base {
     public function instance_config_save($data, $nolongerused = false) {
         if (isset($data->copilotendpointurl)) {
             $data->copilotendpointurl = clean_param($data->copilotendpointurl, PARAM_URL);
+            $directlineurl = $this->get_directline_url($data->copilotendpointurl);
+            $data->directlineurl = clean_param($directlineurl, PARAM_URL);
         }
         return parent::instance_config_save($data, $nolongerused);
+    }
+
+    /**
+     * Return the Direct Line API base URI from the Copilot token endpoint URL.
+     *
+     * @param string $copilotendpointurl The Copilot token endpoint URL.
+     * @return string The Direct Line API base URL.
+     */
+    public function get_directline_url($copilotendpointurl) {
+        $copilotendpoint = parse_url($copilotendpointurl);
+        parse_str($copilotendpoint['query'], $query);
+        $base = "{$copilotendpoint['scheme']}://{$copilotendpoint['host']}";
+        $path = "/powervirtualagents/regionalchannelsettings";
+        $url = "{$base}{$path}?api-version={$query['api-version']}";
+        $response = file_get_contents($url);
+        return json_decode($response, true)['channelUrlsById']['directline'];
     }
 }

--- a/lang/en/block_iagora.php
+++ b/lang/en/block_iagora.php
@@ -26,4 +26,5 @@ $string['copilotendpointurl'] = 'Copilot URL';
 $string['copilotendpointurl_desc'] = 'Microsoft Copilot Token Endpoint URL';
 $string['copilotendpointurl_help'] = 'The Microsoft Copilot Token Endpoint URL is used to get the Direct Line token';
 $string['nocopilotendpointurl'] = 'No Copilot Endpoint URL defined for this block. Please configure it in the block parameters';
+$string['nodirectlineurl'] = 'Failed to get Direct Line URL. Please check and update the Copilot Endpoint URL parameter';
 $string['pluginname'] = 'IAGORA';

--- a/templates/chat.mustache
+++ b/templates/chat.mustache
@@ -27,12 +27,14 @@
 
     Context variables required for this template:
     * chatId: The ID of the chat div element where to render the chat block.
-    * tokenEndpointURL: The Copilot Token Endpoint URL for native apps.
+    * directLineURL: The Copilot Direct Line API base URL.
+    * token: The Copilot Direct Line token.
 
     Example context (json):
     {
         "chatId": "iagora_chat_55a6cad25a0f6",
-        "tokenEndpointURL": "https://insert/your/copilot/endpoint/url"
+        "directLineURL": "https://directline.botframework.com",
+        "token": "RCurR_XV9ZA.cwA.BKA.iaJrC8xpy8qbOF5xnR..."
     }
 }}
 {{#pix}} t/message, core {{/pix}}
@@ -47,30 +49,8 @@
   const styleOptions = {
     hideUploadButton: true
   };
-  const tokenEndpointURL = new URL('{{tokenEndpointURL}}');
   const locale = document.documentElement.lang || 'en';
-  const apiVersion = tokenEndpointURL.searchParams.get('api-version');
-
-  const [directLineURL, token] = await Promise.all([
-    fetch(new URL(`/powervirtualagents/regionalchannelsettings?api-version=${apiVersion}`, tokenEndpointURL))
-      .then(response => {
-        if (!response.ok) {
-          throw new Error('Failed to retrieve regional channel settings.');
-        }
-        return response.json();
-      })
-      .then(({channelUrlsById: {directline}}) => directline),
-    fetch(tokenEndpointURL)
-      .then(response => {
-        if (!response.ok) {
-          throw new Error('Failed to retrieve Direct Line token.');
-        }
-        return response.json();
-      })
-      .then(({token}) => token)
-  ]);
-
-  const directLine = WebChat.createDirectLine({domain: new URL('v3/directline', directLineURL), token});
+  const directLine = WebChat.createDirectLine({domain: new URL('v3/directline', '{{directLineURL}}'), token: '{{token}}'});
 
   const subscription = directLine.connectionStatus$.subscribe({
     next(value) {


### PR DESCRIPTION
## Purpose

The Copilot Endpoint URL is not a secret per se.
However, we anticipate using a Copilot that requires passing a secret in the Endpoint URL request's header in the future.

## Proposal

To avoid exposing the Copilot Endpoint URL secret to Moodle users, we perform the conversation token request on the backend side.

